### PR TITLE
Sepulworld/adding puppetfile source

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You tell magnum several parameters which will be used for populating the templat
 - maintainer_email: email of mantainer of module
 - copyright_year: defaults to current year.
 - copyright_holder: defaults to mantainer if not declared.
+- puppetfile_git_source: provide git url for puppetfile to use in .fixture.yml and target master branch of modules
 
 ### .magnumrc file
 The values above can be set via a file in your home directory called *_.magnumrc_*

--- a/generator_files/git/gitignore.erb
+++ b/generator_files/git/gitignore.erb
@@ -38,6 +38,9 @@ bin/*
 .vagrant
 pkg
 .git_hooks_installed
+<% if options[:puppetfile_git_source] -%>
+Puppetfile
+<% end -%>
 
 # ignore all module fixtures directories that may exist,
 # except this module's fixtures directory

--- a/generator_files/util/Gemfile.erb
+++ b/generator_files/util/Gemfile.erb
@@ -10,3 +10,6 @@ gem 'puppet-lint', '~> 1.1.0'
 gem 'rspec-puppet', '~> 1.0.1'
 gem 'puppetlabs_spec_helper', '~> 0.8.2'
 gem 'serverspec', '~> 2.6.0'
+<% if options[:puppetfile_git_source] -%>
+gem 'librarian-puppet-simple', '~> 0.0.3'
+<% end -%>

--- a/generator_files/util/Rakefile.erb
+++ b/generator_files/util/Rakefile.erb
@@ -69,3 +69,78 @@ PuppetLint::RakeTask.new :lint do |config|
   config.disable_checks = [ "class_inherits_from_params_class", "disable_autoloader_layout", "80chars" ]
   config.fail_on_warnings = false
 end
+<% if options[:puppetfile_git_source] %>
+Rake::Task[:spec_prep].clear
+desc "Create the fixtures directory"
+task :spec_prep do
+  # Create the required directories and site.pp file
+  FileUtils::mkdir_p("spec/fixtures/modules")
+  FileUtils::mkdir_p("spec/fixtures/manifests")
+  FileUtils::touch("spec/fixtures/manifests/site.pp")
+
+  # First, set up the symlinks that we need (this always includes myself)
+  fixtures("symlinks").each do |source, target|
+    File::exists?(File::dirname(target)) || FileUtils::mkdir(File::dirname(target))
+    File::exists?(target) || FileUtils::ln_sf(source, target)
+  end
+
+  # Pull the latest puppetfile, and cull it to include only the fixtures defined modules
+  sh "git archive --remote=git@<%= options[:puppetfile_git_source] -%> HEAD Puppetfile | tar -x"
+
+  # Create repos var containing only the modules that we actually need.
+  repos = []
+  yaml_content = YAML::load_file("./.fixtures.yml")
+  # If there's a list that I can iterate through, then do that.
+  if yaml_content['fixtures']['repositories'].is_a? Enumerable
+    yaml_content['fixtures']['repositories'].each do |module_name,src|
+      repos << module_name
+    end
+  
+    # Loop through fixtures to keep only the modules that are required.
+    new_pup = File::open("Puppetfile.new","w")
+    valid_module = false
+    old_pup = File::open("Puppetfile","r")
+    old_pup.each_line do |line|
+      if m = line.match("^mod '(.+)'")
+        valid_module = false
+        if repos.include? m[1]
+          valid_module = true
+          new_pup.puts(line)
+        end
+      elsif valid_module ? new_pup.puts(line) : nil
+      end
+    end
+    old_pup.close
+    new_pup.close
+    File::rename("./Puppetfile.new","Puppetfile")
+    sh "librarian-puppet install --path=spec/fixtures/modules"
+  
+    # Check for any missing folders. If anything is missing then actually pull it down the old fashioned way.
+    fixtures("repositories").each do |remote, opts|
+      scm = 'git'
+      if opts.instance_of?(String)
+        target = opts
+      elsif opts.instance_of?(Hash)
+        target = opts["target"]
+        ref = opts["ref"]
+        scm = opts["scm"] if opts["scm"]
+        branch = opts["branch"] if opts["branch"]
+      end
+  
+      unless File::exists?(target) || clone_repo(scm, remote, target, ref, branch)
+        fail "Failed to clone #{scm} repository #{remote} into #{target}"
+      end
+      revision(scm, target, ref) if ref
+    end
+  end
+end
+
+Rake::Task[:spec_clean].clear
+desc "Clean up the fixtures directory"
+task :spec_clean do
+  sh "librarian-puppet clean --path=spec/fixtures/modules"
+  if File.zero?("spec/fixtures/manifests/site.pp")
+    FileUtils::rm_f("spec/fixtures/manifests/site.pp")
+  end
+end
+<% end -%>

--- a/lib/magnum/cli/module.rb
+++ b/lib/magnum/cli/module.rb
@@ -4,11 +4,13 @@ require 'yaml'
 module Magnum
   class Module < Thor
 
+    option :puppetfile_git_source, :type => :string
     desc 'create [MODULE_NAME]', 'Creates a new Puppet module.'
     def create(module_name)
       Magnum::CreateGenerator.new([File.join(Dir.pwd, module_name), module_name], options).invoke_all
     end
 
+    option :puppetfile_git_source, :type => :string
     desc 'init [MODULE_NAME]', 'Initializes an existing Puppet module.'
     def init(module_name)
       Magnum::CreateGenerator.new([File.join(Dir.pwd, module_name), module_name], options).invoke_all

--- a/lib/magnum/generators/create_generator.rb
+++ b/lib/magnum/generators/create_generator.rb
@@ -19,6 +19,9 @@ module Magnum
 
     class_option :copyright_holder,
       type: :string
+    
+    class_option :puppetfile_git_source,
+      type: :string
 
     def write_emptydirs
       empty_directory target.join('manifests')
@@ -192,9 +195,12 @@ module Magnum
       "Magnum (#{Magnum::VERSION.chomp}) last initialized this Puppet module directory on #{Time.now.ctime}."
     end
 
+    def puppetfile_git_source
+      options[:puppetfile_source]
+    end
+
     def default_options
       { module_name: module_name }
     end
-
   end
 end


### PR DESCRIPTION
#### Purpose of this option

To remove the need to manage .fixtures.yml files in every puppet module manually. This manual management of .fixtures.yml will lead to a broken puppet environment.  Allows modules to test against the 'master' branch of dependent modules before they merge into the environments r10k manages.  Allowing us to catch broken dependencies sooner. 
##### Problem Scenario it helps solve

Let A be a module with a dependency B.
A has recently been updated, and it is working. The rspec tests are passing when using module B version 2.1.0, which is the version defined in .fixtures.yml; this is also the version in the current Puppetfile. We tag A with version 1.1.0. Everything works great for 2 months. Module B is updated to perform new tasks, and a release 3.0.0 is tagged, which introduces new variables and removed old ones.
All tests are working well. Puppetfile is updated to use Module B version 3.0.0. All spec tests pass in the module build environment. Module B version 3.0.0 is added to the production Puppetfile
All subsequent puppet runs fail.
##### Example fixtures.yml using Puppetfile for reference

```
fixtures:
  repositories:
    stdlib: 'Puppetfile'
    zookeeper: 'Puppetfile'
    mycompany_software_api: 'Puppetfile'
    mycompany_web_server: 'Puppetfile'

    # If yumclient exists in the Puppetfile, the repo listed here will be ignored.
    yumclient: 'git@gitlab.mygitserver.com:puppet/yumclient.git'

    # If a repo is not found in the Puppetfile, then the repo will be cloned from the indicated repo branch/tag.
    epel:
      repo: 'https://github.com/stahnma/puppet-module-epel.git'
      ref: '1.0.2'
    java:
      repo: 'git://github.com/puppetlabs/puppetlabs-java'
      ref: '1.3.0'
```
##### Example cli command w/ puppetfile_git_source provided

```
magnum module create testmodule --puppetfile_git_source gitlab.mygitserver.com:puppet/puppetfile.git
```

```
$ magnum module help create
Usage:
  magnum module create [MODULE_NAME]

Options:
  [--puppetfile-git-source=PUPPETFILE_GIT_SOURCE]

Creates a new Puppet module.
```
