### PR TITLE
Added ability to run vagrant up in rake

### DIFF
--- a/generator_files/util/Rakefile.erb
+++ b/generator_files/util/Rakefile.erb
@@ -17,6 +17,12 @@ task :test do
   Rake::Task[:syntax].invoke
   Rake::Task[:lint].invoke
   Rake::Task[:unit].invoke
+  Rake::Task[:up].invoke
+end
+
+task :up do
+    Rake::Task[:spec_prep].invoke
+    sh "vagrant up --provision"
 end
 
 # puppet-lint options


### PR DESCRIPTION
Added the `vagrant up --provision` command to rake so all you need to do is run 
`rake` and it will kick off all lint checks, spec tests, as well as serverspec tests.
